### PR TITLE
Expose malloc bdev internal functions to allow for external factories

### DIFF
--- a/include/spdk/bdev_malloc.h
+++ b/include/spdk/bdev_malloc.h
@@ -31,18 +31,33 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SPDK_BDEV_MALLOC_RPC_H
-#define SPDK_BDEV_MALLOC_RPC_H
+/** \file
+ * Malloc Block Device Interface
+ *
+ * For information on why this exists, see json rpc.
+ */
+
+#ifndef SPDK_BDEV_MALLOC_H
+#define SPDK_BDEV_MALLOC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "spdk/stdinc.h"
 
 #include "spdk/bdev.h"
+#include "spdk/json.h"
+#include "spdk/thread.h"
 
-typedef void (*spdk_delete_malloc_complete)(void *cb_arg, int bdeverrno);
+int spdk_bdev_malloc_destruct(void *ctx);
+void spdk_bdev_malloc_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io);
+bool spdk_bdev_malloc_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type);
+struct spdk_io_channel *spdk_bdev_malloc_get_io_channel(void *ctx);
+void spdk_bdev_malloc_write_json_config(struct spdk_bdev *bdev, struct spdk_json_write_ctx *w);
 
-struct spdk_bdev *create_malloc_disk(const char *name, const struct spdk_uuid *uuid,
-				     uint64_t num_blocks, uint32_t block_size);
+#ifdef __cplusplus
+}
+#endif
 
-void delete_malloc_disk(struct spdk_bdev *bdev, spdk_delete_malloc_complete cb_fn, void *cb_arg);
-
-#endif /* SPDK_BDEV_MALLOC_RPC_H */
+#endif /* SPDK_BDEV_MALLOC_H */

--- a/lib/bdev/malloc/bdev_malloc.c
+++ b/lib/bdev/malloc/bdev_malloc.c
@@ -35,6 +35,7 @@
 
 #include "bdev_malloc.h"
 #include "spdk/bdev.h"
+#include "spdk/bdev_malloc.h"
 #include "spdk/conf.h"
 #include "spdk/endian.h"
 #include "spdk/env.h"
@@ -49,8 +50,8 @@
 
 struct malloc_disk {
 	struct spdk_bdev		disk;
-	void				*malloc_buf;
 	TAILQ_ENTRY(malloc_disk)	link;
+	void				*malloc_buf;
 };
 
 struct malloc_task {
@@ -123,8 +124,8 @@ malloc_disk_free(struct malloc_disk *malloc_disk)
 	spdk_dma_free(malloc_disk);
 }
 
-static int
-bdev_malloc_destruct(void *ctx)
+int
+spdk_bdev_malloc_destruct(void *ctx)
 {
 	struct malloc_disk *malloc_disk = ctx;
 
@@ -316,15 +317,15 @@ static int _bdev_malloc_submit_request(struct spdk_io_channel *ch, struct spdk_b
 	return 0;
 }
 
-static void bdev_malloc_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
+void spdk_bdev_malloc_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_io)
 {
 	if (_bdev_malloc_submit_request(ch, bdev_io) != 0) {
 		spdk_bdev_io_complete(bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
 	}
 }
 
-static bool
-bdev_malloc_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
+bool
+spdk_bdev_malloc_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
 {
 	switch (io_type) {
 	case SPDK_BDEV_IO_TYPE_READ:
@@ -340,14 +341,14 @@ bdev_malloc_io_type_supported(void *ctx, enum spdk_bdev_io_type io_type)
 	}
 }
 
-static struct spdk_io_channel *
-bdev_malloc_get_io_channel(void *ctx)
+struct spdk_io_channel *
+spdk_bdev_malloc_get_io_channel(void *ctx)
 {
 	return spdk_copy_engine_get_io_channel();
 }
 
-static void
-bdev_malloc_write_json_config(struct spdk_bdev *bdev, struct spdk_json_write_ctx *w)
+void
+spdk_bdev_malloc_write_json_config(struct spdk_bdev *bdev, struct spdk_json_write_ctx *w)
 {
 	char uuid_str[SPDK_UUID_STRING_LEN];
 
@@ -368,11 +369,11 @@ bdev_malloc_write_json_config(struct spdk_bdev *bdev, struct spdk_json_write_ctx
 }
 
 static const struct spdk_bdev_fn_table malloc_fn_table = {
-	.destruct		= bdev_malloc_destruct,
-	.submit_request		= bdev_malloc_submit_request,
-	.io_type_supported	= bdev_malloc_io_type_supported,
-	.get_io_channel		= bdev_malloc_get_io_channel,
-	.write_config_json	= bdev_malloc_write_json_config,
+	.destruct		= spdk_bdev_malloc_destruct,
+	.submit_request		= spdk_bdev_malloc_submit_request,
+	.io_type_supported	= spdk_bdev_malloc_io_type_supported,
+	.get_io_channel		= spdk_bdev_malloc_get_io_channel,
+	.write_config_json	= spdk_bdev_malloc_write_json_config,
 };
 
 struct spdk_bdev *create_malloc_disk(const char *name, const struct spdk_uuid *uuid,


### PR DESCRIPTION
Allows consumers to create and destroy malloc block-devices as needed without using RPC.