### PR TITLE
support configurable buffer pool sizes for small form deployments

### DIFF
--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -157,6 +157,8 @@ struct spdk_bdev_io_stat {
 struct spdk_bdev_opts {
 	uint32_t bdev_io_pool_size;
 	uint32_t bdev_io_cache_size;
+	uint32_t bdev_buf_small_pool_size;
+	uint32_t bdev_buf_large_pool_size;
 };
 
 void spdk_bdev_get_opts(struct spdk_bdev_opts *opts);


### PR DESCRIPTION
the small and large pool buffer sizes can now be configured through the existent spdk conf file mechanism